### PR TITLE
workaround for domain check at /webgl/index.html and fixed name at top of Log screen 

### DIFF
--- a/electron/util/window.ts
+++ b/electron/util/window.ts
@@ -33,7 +33,23 @@ export const createWindowBomb = async (account: Account, index: number): Promise
         },
     });
 
-    window.loadURL('https://app.bombcrypto.io/webgl/index.html?a=' + new Date().getTime());
+    window.loadURL('https://app.bombcrypto.io/?a=' + new Date().getTime());
+
+    window.webContents.on('did-finish-load', ()=>{
+        let code = `
+            let root = document.getElementById("root")
+
+            root.removeChild(root.children[0])
+        
+        
+            let iframe = document.createElement('iframe');
+            iframe.src = "./webgl/index.html"
+            iframe.width = ${WINDOW_BOMBCRYPTO_IFRAME_WIDTH / factor}
+            iframe.height = ${WINDOW_BOMBCRYPTO_IFRAME_HEIGHT / factor}
+            root.appendChild(iframe)`;
+        window.webContents.executeJavaScript(code);
+    });
+    
     // if (isDev) {
     //     window.loadURL('http://localhost:8080/#/bombcrypto/' + account.name || account.metamaskId);
     // } else {

--- a/src/components/templates/Log-list/index.tsx
+++ b/src/components/templates/Log-list/index.tsx
@@ -23,7 +23,7 @@ const LogList: FC<LogListProps> = ({}) => {
                     <BreadcrumbItem active>{t('Logs')}</BreadcrumbItem>
                 </Breadcrumb>
 
-                <TextTitle>{t('Mapas')}</TextTitle>
+                <TextTitle>{t('Logs')}</TextTitle>
                 <TextSubTitle>{t('Lista das ações executadas pelo bot')}</TextSubTitle>
                 <LogListOrg />
             </Container>


### PR DESCRIPTION
page at /webgl/index.html now doesn't work, so I added a snippet to go to the main page, remove all children from the root and add the iframe.